### PR TITLE
Give fader labels more space

### DIFF
--- a/gui/controlwidget.cpp
+++ b/gui/controlwidget.cpp
@@ -9,14 +9,19 @@
 ControlWidget::ControlWidget(class Management &management, char key)
  :
   _scale(0, MAX_SCALE_VALUE_DEF, MAX_SCALE_VALUE_DEF/100),
-	_flashButton(std::string(1, key)), _nameLabel("<..>"),
-	_management(&management), _preset(nullptr),
-	_fadeUpSpeed(0.0), _fadeDownSpeed(0.0),
-	_fadingValue(0), _targetValue(0),
+	_flashButton(std::string(1, key)),
+	_nameLabel("<..>"),
+	_management(&management),
+	_preset(nullptr),
+	_fadeUpSpeed(0.0),
+	_fadeDownSpeed(0.0),
+	_fadingValue(0),
+	_targetValue(0),
 	_holdUpdates(false)
 {
 	_scale.set_inverted(true);
 	_scale.set_draw_value(false);
+	_scale.set_vexpand(true);
 	_scale.signal_value_changed().
 		connect(sigc::mem_fun(*this, &ControlWidget::onScaleChange));
 	pack_start(_scale, true, true, 0);
@@ -29,12 +34,13 @@ ControlWidget::ControlWidget(class Management &management, char key)
 	pack_start(_flashButton, false, false, 0);
 	_flashButton.show();
 
+	_onCheckButton.set_halign(Gtk::ALIGN_CENTER);
 	_onCheckButton.signal_clicked().
 		connect(sigc::mem_fun(*this, &ControlWidget::onOnButtonClicked));
 	pack_start(_onCheckButton, false, false, 0);
 	_onCheckButton.show();
 
-	pack_start(_eventBox, false, false, 0);
+	//pack_start(_eventBox, false, false, 0);
 	_eventBox.set_events(Gdk::BUTTON_PRESS_MASK);
 	_eventBox.show();
 

--- a/gui/controlwidget.h
+++ b/gui/controlwidget.h
@@ -44,6 +44,8 @@ class ControlWidget : public Gtk::VBox {
 		void UpdateValue(double timePassed);
 		void ChangeManagement(class Management& management, bool moveSliders);
 		
+		Gtk::Widget& NameLabel() { return _eventBox; }
+		
 	private:
 		void writeValue();
 		void onScaleChange();

--- a/gui/controlwindow.cpp
+++ b/gui/controlwindow.cpp
@@ -114,6 +114,8 @@ void ControlWindow::initializeWidgets()
 
 	_vBox.pack_start(_hBox2, true, true);
 	_hBox2.pack_start(_buttonBox, false, false);
+	_controlGrid.set_column_spacing(3);
+	_hBox2.pack_start(_controlGrid, true, true);
 	
 	_soloCheckButton.signal_toggled().connect(sigc::mem_fun(*this, &ControlWindow::onSoloButtonToggled));
 	_buttonBox.pack_start(_soloCheckButton, false, false);
@@ -170,7 +172,12 @@ void ControlWindow::addControl()
 	size_t controlIndex = _controls.size();
 	control->SignalValueChange().connect(sigc::bind(sigc::mem_fun(*this, &ControlWindow::onControlValueChanged), control.get()));
 	control->SignalValueChange().connect(sigc::bind(sigc::mem_fun(*this, &ControlWindow::onControlAssigned), controlIndex));
-	_hBox2.pack_start(*control, true, false, 3);
+	
+	_controlGrid.attach(*control, _controls.size()*2+1, 0, 2, 1);
+	control->NameLabel().set_hexpand(true);
+	bool even = _controls.size()%2==0;
+	_controlGrid.attach(control->NameLabel(), _controls.size()*2, even ? 1 : 2, 4, 1);
+	
 	control->show();
 	_controls.emplace_back(std::move(control));
 }

--- a/gui/controlwindow.h
+++ b/gui/controlwindow.h
@@ -6,6 +6,7 @@
 #include <gtkmm/buttonbox.h>
 #include <gtkmm/checkbutton.h>
 #include <gtkmm/combobox.h>
+#include <gtkmm/grid.h>
 #include <gtkmm/liststore.h>
 #include <gtkmm/scale.h>
 #include <gtkmm/window.h>
@@ -81,6 +82,7 @@ class ControlWindow  : public Gtk::Window {
 		Gtk::ComboBox _faderSetup;
 		Glib::RefPtr<Gtk::ListStore> _faderSetupList;
 		Gtk::HBox _hBoxUpper, _hBox2;
+		Gtk::Grid _controlGrid;
 		Gtk::Button _nameButton, _newFaderSetupButton;
 		Gtk::CheckButton _soloCheckButton;
 		Gtk::HScale _fadeUpSpeed, _fadeDownSpeed;


### PR DESCRIPTION
Labels are now separately placed on a grid. Fixes #59.