### PR TITLE
Make it possible to remove fixtures

### DIFF
--- a/gui/configurationwindow.h
+++ b/gui/configurationwindow.h
@@ -29,7 +29,8 @@ class ConfigurationWindow : public Gtk::Window {
 		}
 		void update() { fillFixturesList(); }
 		void fillFixturesList();
-		bool onAddButtonClicked(GdkEventButton* event);
+		bool onNewButtonClicked(GdkEventButton* event);
+		void onRemoveButtonClicked();
 		void onIncChannelButtonClicked();
 		void onDecChannelButtonClicked();
 		void onSetChannelButtonClicked();
@@ -57,7 +58,8 @@ class ConfigurationWindow : public Gtk::Window {
 		Gtk::VBox _mainBox;
 		Gtk::HButtonBox _buttonBox;
 
-		Gtk::Button _addButton, _incChannelButton, _decChannelButton, _setChannelButton;
+		Gtk::Button _newButton, _removeButton;
+		Gtk::Button _incChannelButton, _decChannelButton, _setChannelButton;
 		std::unique_ptr<Gtk::Menu> _popupMenu;
 		std::vector<std::unique_ptr<Gtk::MenuItem>> _popupMenuItems;
 };

--- a/libtheatre/fixture.cpp
+++ b/libtheatre/fixture.cpp
@@ -152,9 +152,6 @@ Fixture::Fixture(const Fixture& source, class Theatre& theatre) :
 		_functions.emplace_back(new FixtureFunction(*ff, theatre));
 }
 
-Fixture::~Fixture()
-{ }
-
 void Fixture::IncChannel()
 {
 	for(std::unique_ptr<FixtureFunction>& ff : _functions)

--- a/libtheatre/fixture.h
+++ b/libtheatre/fixture.h
@@ -14,12 +14,12 @@ class Fixture : public NamedObject {
 	public:
 		Fixture(class Theatre &theatre, class FixtureType &type, const std::string &name);
 		Fixture(const Fixture& source, class Theatre& theatre);
-		~Fixture();
 
 		const std::vector<std::unique_ptr<FixtureFunction>> &Functions() const
 		{ return _functions; }
 		
 		FixtureType &Type() const { return _type; }
+		
 		std::vector<unsigned> GetChannels() const
 		{
 			std::vector<unsigned> channels;
@@ -30,6 +30,7 @@ class Fixture : public NamedObject {
 			}
 			return channels;
 		}
+		
 		void IncChannel();
 
 		void DecChannel();
@@ -47,8 +48,8 @@ class Fixture : public NamedObject {
 		}
 		inline Color GetColor(const class ValueSnapshot &snapshot) const;
 	private:
-		class Theatre &_theatre;
-		FixtureType &_type;
+		class Theatre& _theatre;
+		FixtureType& _type;
 		std::vector<std::unique_ptr<FixtureFunction>> _functions;
 };
 

--- a/libtheatre/management.h
+++ b/libtheatre/management.h
@@ -63,8 +63,11 @@ class Management {
 		class Folder& GetFolder(const std::string& path);
 		void RemoveFolder(class Folder& folder);
 
-		class FixtureFunctionControl& AddFixtureFunctionControl(class FixtureFunction &function);
-		class FixtureFunctionControl& AddFixtureFunctionControl(class FixtureFunction &function, Folder& parent);
+		class FixtureFunctionControl& AddFixtureFunctionControl(class FixtureFunction& function);
+		class FixtureFunctionControl& AddFixtureFunctionControl(class FixtureFunction& function, Folder& parent);
+		class FixtureFunctionControl& GetFixtureFunctionControl(class FixtureFunction& function);
+		
+		void RemoveFixture(class Fixture& fixture);
 
 		class PresetValue& AddPreset(Controllable &controllable);
 		class PresetValue& AddPreset(unsigned id, Controllable &controllable);

--- a/libtheatre/namedobject.h
+++ b/libtheatre/namedobject.h
@@ -67,6 +67,28 @@ public:
 		throw std::runtime_error("Could not find object in container.");
 	}
 	
+	template<typename ObjectType>
+	static bool Contains(const std::vector<std::unique_ptr<ObjectType>>& container, const ObjectType* element)
+	{
+		for(const std::unique_ptr<ObjectType>& obj : container)
+		{
+			if(obj.get() == &element)
+				return true;
+		}
+		return false;
+	}
+	
+	template<typename ObjectType>
+	static bool Contains(const std::vector<std::unique_ptr<ObjectType>>& container, const std::string& name)
+	{
+		for(const std::unique_ptr<ObjectType>& obj : container)
+		{
+			if(obj->_name == name)
+				return true;
+		}
+		return false;
+	}
+	
 	sigc::signal<void()>& SignalDelete() { return _signalDelete; }
 		
 private:

--- a/libtheatre/theatre.h
+++ b/libtheatre/theatre.h
@@ -29,6 +29,10 @@ class Theatre {
 		class Fixture& GetFixture(const std::string &name) const;
 		class FixtureType& GetFixtureType(const std::string &name) const;
 		class FixtureFunction& GetFixtureFunction(const std::string &name) const;
+		
+		void RemoveFixture(Fixture& fixture);
+		
+		bool IsUsed(FixtureType& fixtureType) const;
 
 		unsigned HighestChannel() const { return _highestChannel; }
 		unsigned FirstFreeChannel() const { return _fixtures.empty() ? 0 : _highestChannel+1; }


### PR DESCRIPTION
Fixes #52. Also the naming system for new fixtures has been updated to reuse names
of removed fixtures, and don't call 3rd fixture 'C' if a fixture with that name already
exists.