### PR TITLE
Fix fade effect values to be compatible with duration widget

### DIFF
--- a/theatre/effects/fadeeffect.h
+++ b/theatre/effects/fadeeffect.h
@@ -19,14 +19,14 @@ public:
 	
 	virtual Effect::Type GetType() const override { return FadeType; }
 	
-	double FadeUpSpeed() const { return _fadeUpSpeed; }
-	void SetFadeUpSpeed(double speed) { _fadeUpSpeed = speed; }
+	double FadeUpDuration() const { return _fadeUpSpeed==0.0 ? 0.0 : 1.0e3 / _fadeUpSpeed; }
+	void SetFadeUpDuration(double durationMS) { _fadeUpSpeed = durationMS == 0.0 ? 0.0 : 1.0e3 / durationMS; }
 	
-	double FadeDownSpeed() const { return _fadeDownSpeed; }
-	void SetFadeDownSpeed(double speed) { _fadeDownSpeed = speed; }
+	double FadeDownDuration() const { return _fadeDownSpeed==0.0 ? 0.0 : 1.0e3 / _fadeDownSpeed; }
+	void SetFadeDownDuration(double durationMS) { _fadeDownSpeed = durationMS == 0.0 ? 0.0 : 1.0e3 / durationMS; }
 	
-	double Sustain() const { return _sustain; }
-	void SetSustain(double sustain) { _sustain = sustain; }
+	double Sustain() const { return _sustain * 1e3; }
+	void SetSustain(double sustainMS) { _sustain = 1e-3 * sustainMS; }
 	
 protected:
 	virtual void mix(const ControlValue* values, unsigned*, unsigned, const Timing& timing) final override

--- a/theatre/properties/fadeeffectps.h
+++ b/theatre/properties/fadeeffectps.h
@@ -10,8 +10,8 @@ class FadeEffectPS final : public PropertySet
 public:
 	FadeEffectPS()
 	{
-		addProperty(Property("upspeed", "Up fading speed", Property::Duration));
-		addProperty(Property("downspeed", "Down fading speed", Property::Duration));
+		addProperty(Property("upduration", "Up fading duration", Property::Duration));
+		addProperty(Property("downduration", "Down fading duration", Property::Duration));
 		addProperty(Property("sustaintime", "Sustain time", Property::Duration));
 	}
 	
@@ -20,8 +20,8 @@ protected:
 	{
 		FadeEffect& fadefx = static_cast<FadeEffect&>(object);
 		switch(index) {
-			case 0: fadefx.SetFadeUpSpeed(value); break;
-			case 1: fadefx.SetFadeDownSpeed(value); break;
+			case 0: fadefx.SetFadeUpDuration(value); break;
+			case 1: fadefx.SetFadeDownDuration(value); break;
 			case 2: fadefx.SetSustain(value); break;
 		}
 	}
@@ -30,8 +30,8 @@ protected:
 	{
 		const FadeEffect& fadefx = static_cast<const FadeEffect&>(object);
 		switch(index) {
-			case 0: return fadefx.FadeUpSpeed();
-			case 1: return fadefx.FadeDownSpeed();
+			case 0: return fadefx.FadeUpDuration();
+			case 1: return fadefx.FadeDownDuration();
 			case 2: return fadefx.Sustain();
 		}
 		return 0;


### PR DESCRIPTION
The fade effect properties were not actually durations. However changing them with a duration box is much easier.
Because the speed properties were changed to duration properties, they were also renamed in save files. This implies that older save files will no longer load with this new version.