### PR TITLE
Fix bug causing faders sometimes to become unasigned

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,6 +106,7 @@ if(Boost_FOUND)
     tests/testfolder.cpp
     tests/testmanagement.cpp
     tests/testpresetcollection.cpp
+    tests/testpresetvalue.cpp
     )
   target_link_libraries(runtests ${GLIGHT_LIBRARIES})
   add_test(runtests runtests)

--- a/tests/testpresetvalue.cpp
+++ b/tests/testpresetvalue.cpp
@@ -1,0 +1,38 @@
+#include "../theatre/presetcollection.h"
+#include "../theatre/presetvalue.h"
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_AUTO_TEST_SUITE(presetvalue)
+
+BOOST_AUTO_TEST_CASE( SignalDelete )
+{
+	PresetCollection collection;
+	std::unique_ptr<PresetValue> value(new PresetValue(collection, 37));
+	bool isCalled = false;
+	value->SignalDelete().connect( [&isCalled](){ isCalled = true; } );
+	BOOST_CHECK_EQUAL(isCalled, false);
+	value.reset();
+	BOOST_CHECK_EQUAL(isCalled, true);
+}
+
+BOOST_AUTO_TEST_CASE( Copy )
+{
+	PresetCollection collection;
+	PresetValue value(collection, 42);
+	PresetValue copy(value);
+	
+	BOOST_CHECK_EQUAL(&copy.Controllable(), &collection);
+	BOOST_CHECK_EQUAL(copy.InputIndex(), 42);
+	
+	bool isCalled = false;
+	value.SignalDelete().connect( [&isCalled](){ isCalled = true; } );
+	BOOST_CHECK_EQUAL(isCalled, false);
+
+	std::unique_ptr<PresetValue> destructedCopy(new PresetValue(value));
+	destructedCopy.reset();
+	BOOST_CHECK_EQUAL(isCalled, false);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+

--- a/theatre/presetvalue.h
+++ b/theatre/presetvalue.h
@@ -16,7 +16,14 @@ class PresetValue {
 			: _value(0), _controllable(&controllable), _inputIndex(inputIndex)
 		{ }
 		
-		PresetValue(const PresetValue &source) = default;
+		/**
+		 * Copy the preset value. The delete signal is not copied.
+		 */
+		PresetValue(const PresetValue& source) :
+			_value(source._value),
+			_controllable(source._controllable),
+			_inputIndex(source._inputIndex)
+		{ }
 		
 		/**
 		 * Copy constructor that copies the source but associates it with the given controllable.


### PR DESCRIPTION
Fixes #168.
Caused by copying the PresetValue class into PresetCollections, including
their delete handler. This would call the delete handler for the presets
that the fader were connected to.