### PR TITLE
Fix dry mode crash when having deep dir structure

### DIFF
--- a/tests/testfolder.cpp
+++ b/tests/testfolder.cpp
@@ -123,6 +123,23 @@ BOOST_AUTO_TEST_CASE( FollowDown )
 	BOOST_CHECK_EQUAL( a->FollowDown("b/c") , c.get() );
 	
 	BOOST_CHECK_EQUAL( b->FollowDown("c") , c.get() );
+	
+	std::unique_ptr<Folder> root(new Folder("root"));
+	std::unique_ptr<Folder> f1(new Folder("bert"));
+	std::unique_ptr<Folder> f2(new Folder("carole"));
+	std::unique_ptr<Folder> f3(new Folder("daniel"));
+	f2->Add(*f3);
+	f1->Add(*f2);
+	root->Add(*f1);
+	BOOST_CHECK_EQUAL(
+		root->FollowDown(Folder::RemoveRoot("root/bert/carole/daniel")),
+		f3.get()
+	);
+	std::string notMoved = Folder::RemoveRoot("root/bert/carole/daniel");
+	BOOST_CHECK_EQUAL(
+		root->FollowDown(notMoved),
+		f3.get()
+	);
 }
 
 

--- a/theatre/folder.h
+++ b/theatre/folder.h
@@ -239,7 +239,7 @@ private:
 			return dynamic_cast<Folder*>(obj);
 		}
 		else {
-			FolderObject* obj = FindNamedObjectIfExists(_objects, path.substr(strPos, sep-path.begin()));
+			FolderObject* obj = FindNamedObjectIfExists(_objects, path.substr(strPos, sep-path.begin()-strPos));
 			Folder* folder = dynamic_cast<Folder*>(obj);
 			if(folder)
 				return folder->followDown(path, sep+1-path.begin());
@@ -258,7 +258,7 @@ private:
 			return dynamic_cast<Folder*>(obj);
 		}
 		else {
-			FolderObject* obj = FindNamedObjectIfExists(_objects, path.substr(strPos, sep-path.begin()));
+			FolderObject* obj = FindNamedObjectIfExists(_objects, path.substr(strPos, sep-path.begin()-strPos));
 			Folder* folder = dynamic_cast<Folder*>(obj);
 			if(folder)
 				return folder->followDown(std::move(path), sep+1-path.begin());


### PR DESCRIPTION
Deep dir structures would cause followDown() to incorrectly return nullptr.