### PR TITLE
Support filters that apply of fixtures and add monochrome filter as example

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,6 +144,8 @@ set(EXTERNALFILES
 
 include_directories(external/hsluv)
 
+include_directories($<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
+
 add_library(glight-object OBJECT
   ${GUIFILES} ${SYSTEMFILES} ${THEATREFILES} ${EXTERNALFILES})
 
@@ -190,6 +192,7 @@ if(Boost_FOUND)
     tests/tscene.cpp
     tests/ttheatre.cpp
     tests/tuniquewithoutordering.cpp
+    tests/theatre/filters/tmonochromefilter.cpp
     )
   target_link_directories(runtests PRIVATE ${GTKMM_LIBDIR} ${LIBOLA_LIBDIR})
   target_link_libraries(runtests ${GLIGHT_LIBRARIES})

--- a/gui/faders/faderwindow.cpp
+++ b/gui/faders/faderwindow.cpp
@@ -197,7 +197,7 @@ void FaderWindow::loadState() {
 
     _crossFader.emplace(
         Gtk::Adjustment::create(
-            0, ControlValue::MaxUInt() + ControlValue::MaxUInt() / 100,
+            0, 0, ControlValue::MaxUInt() + ControlValue::MaxUInt() / 100,
             (ControlValue::MaxUInt() + 1) / 100),
         Gtk::ORIENTATION_VERTICAL);
     _leftBox.pack_start(*_crossFader, true, true);
@@ -624,7 +624,7 @@ void FaderWindow::UpdateValues() {
   if (_crossFader && assigned_source_value) {
     const unsigned x_value = assigned_source_value->CrossFader().Value().UInt();
     if (_isCrossFaderStarted) {
-      if (x_value == 0.0) {
+      if (x_value == 0) {
         AssignTopToBottom();
       }
     }

--- a/gui/windows/addfixturewindow.h
+++ b/gui/windows/addfixturewindow.h
@@ -3,8 +3,10 @@
 
 #include <gtkmm/box.h>
 #include <gtkmm/button.h>
+#include <gtkmm/checkbutton.h>
 #include <gtkmm/combobox.h>
 #include <gtkmm/entry.h>
+#include <gtkmm/frame.h>
 #include <gtkmm/grid.h>
 #include <gtkmm/label.h>
 #include <gtkmm/liststore.h>
@@ -48,6 +50,8 @@ class AddFixtureWindow : public Gtk::Window {
   Gtk::Entry _countEntry;
   Gtk::Button _decCountButton;
   Gtk::Button _incCountButton;
+  Gtk::Frame filters_frame_;
+  Gtk::CheckButton monochrome_cb_;
   Gtk::Box _buttonBox;
   Gtk::Button _cancelButton;
   Gtk::Button _addButton;

--- a/tests/tfixturecontrol.cpp
+++ b/tests/tfixturecontrol.cpp
@@ -24,7 +24,7 @@ BOOST_AUTO_TEST_CASE(SetValue) {
   std::vector<unsigned> values(512, 0);
   Timing timing(0.0, 0, 0, 0, 0);
   control.Mix(timing, true);
-  control.MixChannels(values.data(), 0);
+  control.GetChannelValues(values.data(), 0);
   for (size_t i = 0; i != 512; ++i) {
     if (i == 100)
       BOOST_CHECK_EQUAL(values[100], ControlValue::MaxUInt());

--- a/tests/theatre/filters/tmonochromefilter.cpp
+++ b/tests/theatre/filters/tmonochromefilter.cpp
@@ -1,0 +1,52 @@
+#include "theatre/filters/monochromefilter.h"
+
+#include <boost/test/unit_test.hpp>
+
+using namespace glight::theatre;
+
+BOOST_AUTO_TEST_SUITE(monochrome_filter)
+
+BOOST_AUTO_TEST_CASE(types) {
+  MonochromeFilter filter;
+  filter.SetOutputTypes({
+      FunctionType::Master,
+      FunctionType::Red,
+      FunctionType::Green,
+      FunctionType::Blue,
+      FunctionType::Strobe,
+  });
+  BOOST_REQUIRE_EQUAL(filter.InputTypes().size(), 3);
+  BOOST_CHECK(filter.InputTypes()[0] == FunctionType::White);
+  BOOST_CHECK(filter.InputTypes()[1] == FunctionType::Master);
+  BOOST_CHECK(filter.InputTypes()[2] == FunctionType::Strobe);
+
+  filter.SetOutputTypes({FunctionType::White});
+  BOOST_REQUIRE_EQUAL(filter.InputTypes().size(), 1);
+  BOOST_CHECK(filter.InputTypes()[0] == FunctionType::White);
+}
+
+BOOST_AUTO_TEST_CASE(apply) {
+  MonochromeFilter filter;
+  filter.SetOutputTypes({
+      FunctionType::Master,
+      FunctionType::Red,
+      FunctionType::Green,
+      FunctionType::Blue,
+      FunctionType::Strobe,
+  });
+  std::vector<ControlValue> output(5);
+  filter.Apply(
+      {
+          ControlValue(10),  // white
+          ControlValue(20),  // master
+          ControlValue(30)   // strobe
+      },
+      output);
+  BOOST_CHECK_EQUAL(output[0].UInt(), 20);  // master
+  BOOST_CHECK_EQUAL(output[1].UInt(), 10);  // red
+  BOOST_CHECK_EQUAL(output[2].UInt(), 10);  // gren
+  BOOST_CHECK_EQUAL(output[3].UInt(), 10);  // blue
+  BOOST_CHECK_EQUAL(output[4].UInt(), 30);  // strobe
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/tests/tpresetcollection.cpp
+++ b/tests/tpresetcollection.cpp
@@ -51,7 +51,7 @@ BOOST_AUTO_TEST_CASE(SetValue) {
   // Mix controls in order of dependencies
   presetCollection.Mix(timing, true);
   fixtureControl.Mix(timing, true);
-  fixtureControl.MixChannels(values.data(), 0);
+  fixtureControl.GetChannelValues(values.data(), 0);
   for (size_t i = 0; i != 512; ++i) {
     if (i == 100) {
       // it's not accurately Max, because of truncations.

--- a/theatre/filters/filter.h
+++ b/theatre/filters/filter.h
@@ -1,0 +1,61 @@
+#ifndef THEATRE_FILTER_H_
+#define THEATRE_FILTER_H_
+
+#include "../controlvalue.h"
+#include "../folderobject.h"
+#include "../functiontype.h"
+
+namespace glight::theatre {
+
+class Filter {
+ public:
+  Filter() noexcept = default;
+
+  virtual ~Filter() = default;
+
+  const std::vector<FunctionType>& InputTypes() const { return input_types_; }
+  const std::vector<FunctionType>& OutputTypes() const { return output_types_; }
+
+  /**
+   * Determines the input types that this filter provides from the output
+   * types, and calls @ref SetInputTypes() accordingly.
+   * This function is called when the filter is connected to a filter
+   * or a fixture.
+   *
+   * For example, a filter that converts an RGB fixture to white only
+   * might replace the R, G and B functions by a single white function,
+   * and copy other functions (master channel, strobe, etc.) from the output.
+   */
+  virtual void DetermineInputTypes() = 0;
+
+  /**
+   * Set the output types, which connects this filter to another filter or
+   * fixture and adapts the input types accordingly.
+   */
+  void SetOutputTypes(std::vector<FunctionType> output_functions) {
+    output_types_ = std::move(output_functions);
+    DetermineInputTypes();
+  }
+
+  /**
+   * Applies the filter to the input and sets the output accordingly.
+   * @param input should have a size of InputTypes().size().
+   * @param output Output parameter. On input, should have a size equal to
+   * OutputTypes().size().
+   */
+  virtual void Apply(const std::vector<ControlValue>& input,
+                     std::vector<ControlValue>& output) = 0;
+
+ protected:
+  void SetInputTypes(std::vector<FunctionType> input_types) {
+    input_types_ = std::move(input_types);
+  }
+
+ private:
+  std::vector<FunctionType> input_types_;
+  std::vector<FunctionType> output_types_;
+};
+
+}  // namespace glight::theatre
+
+#endif

--- a/theatre/filters/monochromefilter.h
+++ b/theatre/filters/monochromefilter.h
@@ -1,0 +1,42 @@
+#ifndef GLIGHT_THEATRE_MONOCHROME_FILTER_H_
+#define GLIGHT_THEATRE_MONOCHROME_FILTER_H_
+
+#include <cassert>
+
+#include "filter.h"
+
+#include "../functiontype.h"
+
+namespace glight::theatre {
+
+class MonochromeFilter final : public Filter {
+ public:
+  void Apply(const std::vector<ControlValue>& input,
+             std::vector<ControlValue>& output) override {
+    assert(input.size() == InputTypes().size());
+    assert(output.size() == OutputTypes().size());
+    size_t input_index = 1;
+    for (size_t output_index = 0; output_index != OutputTypes().size();
+         ++output_index) {
+      if (IsColor(OutputTypes()[output_index])) {
+        output[output_index] = input[0];
+      } else {
+        output[output_index] = input[input_index];
+        ++input_index;
+      }
+    }
+  }
+
+ protected:
+  void DetermineInputTypes() override {
+    std::vector<FunctionType> input_types{FunctionType::White};
+    for (FunctionType type : OutputTypes()) {
+      if (!IsColor(type)) input_types.emplace_back(type);
+    }
+    SetInputTypes(std::move(input_types));
+  }
+};
+
+}  // namespace glight::theatre
+
+#endif

--- a/theatre/fixturefunction.h
+++ b/theatre/fixturefunction.h
@@ -39,13 +39,13 @@ class FixtureFunction final : public NamedObject {
       } else {  // 16 bit
         const unsigned currentValue =
             (channels[_firstChannel.Channel()]) +
-            (channels[_firstChannel.Channel() + 1] >> 8);
+            (channels[_firstChannel.Next().Channel()] >> 8);
         const unsigned mixedValue =
             ControlValue::Mix(currentValue, value, combiMixStyle);
         // Set to the first 8 of 24 bits.
         channels[_firstChannel.Channel()] = (mixedValue & (~0xFFFF));
-        // Set to bits 9-24.
-        channels[_firstChannel.Channel() + 1] = (mixedValue & 0xFFFF) << 8;
+        // Set to bits 9-16.
+        channels[_firstChannel.Next().Channel()] = (mixedValue & 0xFFFF) << 8;
       }
     }
   }

--- a/theatre/functiontype.h
+++ b/theatre/functiontype.h
@@ -233,6 +233,37 @@ inline std::string ToString(FunctionType functionType) {
   return "?";
 }
 
+inline bool IsColor(FunctionType type) {
+  switch (type) {
+    case FunctionType::ColorMacro:
+    case FunctionType::Effect:
+    case FunctionType::Lightness:
+    case FunctionType::Master:
+    case FunctionType::Pulse:
+    case FunctionType::RotationSpeed:
+    case FunctionType::Pan:
+    case FunctionType::Saturation:
+    case FunctionType::Strobe:
+    case FunctionType::Tilt:
+    case FunctionType::Zoom:
+    case FunctionType::Unknown:
+    case FunctionType::Hue:
+      return false;
+    case FunctionType::Red:
+    case FunctionType::Green:
+    case FunctionType::Blue:
+    case FunctionType::White:
+    case FunctionType::Amber:
+    case FunctionType::UV:
+    case FunctionType::Lime:
+    case FunctionType::ColdWhite:
+    case FunctionType::WarmWhite:
+    case FunctionType::ColorTemperature:
+      return true;
+  }
+  return false;
+}
+
 inline constexpr Color GetFunctionColor(FunctionType type) {
   switch (type) {
     case FunctionType::ColorMacro:

--- a/theatre/management.cpp
+++ b/theatre/management.cpp
@@ -202,7 +202,7 @@ void Management::MixAll(unsigned timestep_number, ValueSnapshot &primary,
     ValueSnapshot &snapshot = is_primary ? primary : secondary;
     for (unsigned universe = 0; universe != n_universes; ++universe) {
       if (_device->GetUniverseType(universe) == UniverseType::Output) {
-        ProcessInputUniverse(universe, timestep_number, snapshot, is_primary);
+        ProcessInputUniverse(universe, snapshot, is_primary);
       }
     }
   }

--- a/theatre/management.cpp
+++ b/theatre/management.cpp
@@ -82,31 +82,32 @@ void Management::Run() {
 }
 
 void Management::ProcessInputUniverse(unsigned universe,
-                                      unsigned timestep_number,
-                                      ValueSnapshot &next_primary,
-                                      ValueSnapshot &next_secondary) {
-  for (bool is_primary : {true, false}) {
-    unsigned values[512];
-    unsigned char values_char[512];
+                                      ValueSnapshot &snapshot,
+                                      bool is_primary) {
+  unsigned values[512];
+  unsigned char values_char[512];
 
-    std::fill_n(values, 512, 0);
+  std::fill_n(values, 512, 0);
 
-    getChannelValues(timestep_number, values, universe, is_primary);
-
-    for (unsigned i = 0; i < 512; ++i) {
-      unsigned val = (values[i] >> 16);
-      if (val > 255) val = 255;
-      values_char[i] = static_cast<unsigned char>(val);
+  for (const std::unique_ptr<Controllable> &controllable : _controllables) {
+    if (FixtureControl *fc =
+            dynamic_cast<FixtureControl *>(controllable.get())) {
+      fc->MixChannels(values, universe);
     }
+  }
 
-    ValueUniverseSnapshot &universe_values =
-        is_primary ? next_primary.GetUniverseSnapshot(universe)
-                   : next_secondary.GetUniverseSnapshot(universe);
-    universe_values.SetValues(values_char, _theatre->HighestChannel() + 1);
+  for (unsigned i = 0; i < 512; ++i) {
+    unsigned val = (values[i] >> 16);
+    if (val > 255) val = 255;
+    values_char[i] = static_cast<unsigned char>(val);
+  }
 
-    if (is_primary) {
-      _device->SetOutputValues(universe, values_char, 512);
-    }
+  ValueUniverseSnapshot &universe_values =
+      snapshot.GetUniverseSnapshot(universe);
+  universe_values.SetValues(values_char, _theatre->HighestChannel() + 1);
+
+  if (is_primary) {
+    _device->SetOutputValues(universe, values_char, 512);
   }
 }
 
@@ -118,12 +119,7 @@ void Management::ThreadLoop() {
       std::make_unique<ValueSnapshot>(false, n_universes);
   unsigned timestep_number = 0;
   while (!_isQuitting) {
-    for (unsigned universe = 0; universe != n_universes; ++universe) {
-      if (_device->GetUniverseType(universe) == UniverseType::Output) {
-        ProcessInputUniverse(universe, timestep_number, *next_primary,
-                             *next_secondary);
-      }
-    }
+    MixAll(timestep_number, *next_primary, *next_secondary);
     _device->WaitForNextSync();
 
     std::lock_guard<std::mutex> lock(_mutex);
@@ -136,8 +132,8 @@ void Management::ThreadLoop() {
 
 void Management::abortAllDevices() { _device->Abort(); }
 
-void Management::getChannelValues(unsigned timestepNumber, unsigned *values,
-                                  unsigned universe, bool primary) {
+void Management::MixAll(unsigned timestep_number, ValueSnapshot &primary,
+                        ValueSnapshot &secondary) {
   const double relTimeInMs = GetOffsetTimeInMS();
   double beatValue = 0.0;
   unsigned audioLevel = 0;
@@ -157,7 +153,7 @@ void Management::getChannelValues(unsigned timestepNumber, unsigned *values,
     audioLevel = 0;
 
   const unsigned randomValue = _rndDistribution(_randomGenerator);
-  const Timing timing(relTimeInMs, timestepNumber, beatValue, audioLevel,
+  const Timing timing(relTimeInMs, timestep_number, beatValue, audioLevel,
                       randomValue);
   const double timePassed = (relTimeInMs - _previousTime) * 1e-3;
   _previousTime = relTimeInMs;
@@ -165,23 +161,6 @@ void Management::getChannelValues(unsigned timestepNumber, unsigned *values,
   std::lock_guard<std::mutex> lock(_mutex);
   for (std::unique_ptr<SourceValue> &sv : _sourceValues) {
     sv->ApplyFade(timePassed);
-  }
-  // Reset all inputs
-  for (const std::unique_ptr<SourceValue> &sv : _sourceValues) {
-    for (size_t inputIndex = 0; inputIndex != sv->GetControllable().NInputs();
-         ++inputIndex) {
-      sv->GetControllable().InputValue(inputIndex) = ControlValue(0);
-    }
-  }
-
-  if (primary) {
-    for (const std::unique_ptr<SourceValue> &sv : _sourceValues)
-      sv->GetControllable().MixInput(sv->InputIndex(),
-                                     ControlValue(sv->PrimaryValue()));
-  } else {
-    for (const std::unique_ptr<SourceValue> &sv : _sourceValues)
-      sv->GetControllable().MixInput(sv->InputIndex(),
-                                     ControlValue(sv->SecondaryValue()));
   }
 
   // Solve dependency graph of controllables
@@ -192,10 +171,39 @@ void Management::getChannelValues(unsigned timestepNumber, unsigned *values,
   if (!topologicalSort(unorderedList, orderedList))
     throw std::runtime_error("Cycle in dependencies");
 
-  for (Controllable *controllable : std::ranges::reverse_view(orderedList)) {
-    controllable->Mix(timing, primary);
-    if (FixtureControl *fc = dynamic_cast<FixtureControl *>(controllable)) {
-      fc->MixChannels(values, universe);
+  for (bool is_primary : {false, true}) {
+    // Reset all inputs
+    for (const std::unique_ptr<SourceValue> &sv : _sourceValues) {
+      for (size_t inputIndex = 0; inputIndex != sv->GetControllable().NInputs();
+           ++inputIndex) {
+        sv->GetControllable().InputValue(inputIndex) = ControlValue(0);
+      }
+    }
+
+    // Process source values. These will output to controllables.
+    if (is_primary) {
+      for (const std::unique_ptr<SourceValue> &sv : _sourceValues)
+        sv->GetControllable().MixInput(sv->InputIndex(),
+                                       ControlValue(sv->PrimaryValue()));
+    } else {
+      for (const std::unique_ptr<SourceValue> &sv : _sourceValues)
+        sv->GetControllable().MixInput(sv->InputIndex(),
+                                       ControlValue(sv->SecondaryValue()));
+    }
+
+    // Process all controllables that follow
+    for (Controllable *controllable : std::ranges::reverse_view(orderedList)) {
+      controllable->Mix(timing, is_primary);
+    }
+
+    // All controllables have provided their output; now obtain the DMX values
+    // and store them in the ValueSnapshot.
+    const unsigned n_universes = _device->NUniverses();
+    ValueSnapshot &snapshot = is_primary ? primary : secondary;
+    for (unsigned universe = 0; universe != n_universes; ++universe) {
+      if (_device->GetUniverseType(universe) == UniverseType::Output) {
+        ProcessInputUniverse(universe, timestep_number, snapshot, is_primary);
+      }
     }
   }
 }

--- a/theatre/management.cpp
+++ b/theatre/management.cpp
@@ -92,7 +92,7 @@ void Management::ProcessInputUniverse(unsigned universe,
   for (const std::unique_ptr<Controllable> &controllable : _controllables) {
     if (FixtureControl *fc =
             dynamic_cast<FixtureControl *>(controllable.get())) {
-      fc->MixChannels(values, universe);
+      fc->GetChannelValues(values, universe);
     }
   }
 

--- a/theatre/management.h
+++ b/theatre/management.h
@@ -149,12 +149,22 @@ class Management {
 
  private:
   void ThreadLoop();
-  void ProcessInputUniverse(unsigned universe, unsigned timestep_number,
-                            ValueSnapshot &next_primary,
-                            ValueSnapshot &next_secondary);
 
-  void getChannelValues(unsigned timestepNumber, unsigned *values,
-                        unsigned universe, bool primary);
+  /**
+   * Prepares the dependency chain, and propagates values starting at the
+   * source values through the controllables.
+   */
+  void MixAll(unsigned timestep_number, ValueSnapshot &primary,
+              ValueSnapshot &secondary);
+
+  /**
+   * Obtains the channel values from the current situation of the controllables.
+   * If this is the primary snapshot, the values are also send to the DMX
+   * device.
+   */
+  void ProcessInputUniverse(unsigned universe, ValueSnapshot &snapshot,
+                            bool is_primary);
+
   void removeControllable(
       std::vector<std::unique_ptr<Controllable>>::iterator controllablePtr);
 


### PR DESCRIPTION
Fixes #361.

This MR also fixes a bug in the cross fader when fader layout is in dual. It also cleans up the Management-class's thread loop function.