### PR TITLE
Add fader button to toggle control

### DIFF
--- a/gui/components/objectlist.cpp
+++ b/gui/components/objectlist.cpp
@@ -32,6 +32,7 @@ ObjectList::ObjectList()
   _listView.set_model(_listModel);
   _listView.append_column("", _listColumns._icon);
   _listView.append_column("object", _listColumns._title);
+  _listView.set_enable_search(false);
   _listView.get_selection()->signal_changed().connect([&]() {
     if (_avoidRecursion.IsFirst()) _signalSelectionChange.emit();
   });

--- a/gui/faders/faderwidget.cpp
+++ b/gui/faders/faderwidget.cpp
@@ -25,7 +25,7 @@ FaderWidget::FaderWidget(FaderWindow &fader_window, FaderState &state,
                  0, 0, ControlValue::MaxUInt() + ControlValue::MaxUInt() / 100,
                  (ControlValue::MaxUInt() + 1) / 100),
              Gtk::ORIENTATION_VERTICAL),
-      _flashButton(std::string(1, key)) {
+      flash_button_label_(std::string(1, key)) {
   if (GetMode() == ControlMode::Primary) {
     _fadeUpButton.set_image_from_icon_name("go-up");
     _fadeUpButton.signal_clicked().connect([&]() { onFadeUp(); });
@@ -82,6 +82,11 @@ FaderWidget::FaderWidget(FaderWindow &fader_window, FaderState &state,
     _fadeDownButton.set_margin_bottom(10);
     _overlay.add_overlay(_fadeDownButton);
 
+    // The flash button label is added manually because it takes less space
+    // like this.
+    _flashButton.add(flash_button_label_);
+    flash_button_label_.show();
+    flash_button_label_.set_hexpand(false);
     _flashButton.set_events(Gdk::BUTTON_PRESS_MASK);
     _flashButton.signal_button_press_event().connect(
         sigc::mem_fun(*this, &FaderWidget::onFlashButtonPressed), false);
@@ -90,6 +95,7 @@ FaderWidget::FaderWidget(FaderWindow &fader_window, FaderState &state,
         sigc::mem_fun(*this, &FaderWidget::onFlashButtonReleased), false);
     _box.pack_start(_flashButton, false, false, 0);
     _flashButton.set_visible(state.DisplayFlashButton());
+    _flashButton.set_hexpand(false);
   }
 
   _checkButton.set_halign(Gtk::ALIGN_CENTER);
@@ -257,7 +263,8 @@ bool FaderWidget::HandleRightRelease(GdkEventButton *event) {
 
 void FaderWidget::UpdateDisplaySettings() {
   _nameLabel.set_visible(State().DisplayName());
-  _flashButton.set_visible(State().DisplayFlashButton());
+  _flashButton.set_visible(State().DisplayFlashButton() &&
+                           GetMode() == ControlMode::Primary);
   _checkButton.set_visible(State().DisplayCheckButton());
 }
 

--- a/gui/faders/faderwidget.h
+++ b/gui/faders/faderwidget.h
@@ -59,6 +59,7 @@ class FaderWidget final : public ControlWidget {
   Gtk::Scale _scale;
   Gtk::Button _fadeDownButton;
   Gtk::Button _flashButton;
+  Gtk::Label flash_button_label_;
   IconButton _checkButton;
   Gtk::EventBox _labelEventBox;
   Gtk::Label _nameLabel{"<..>"};

--- a/gui/faders/togglewidget.h
+++ b/gui/faders/togglewidget.h
@@ -27,24 +27,27 @@ class ToggleWidget final : public ControlWidget {
   virtual void Limit(double value) override;
 
  private:
-  Gtk::HBox _box;
-  Gtk::VBox _flashButtonBox;
-  Gtk::Button _flashButton;
-  IconButton _iconButton;
-  Gtk::EventBox _eventBox;
-  Gtk::Label _nameLabel;
+  Gtk::HBox box_;
+  Gtk::Label flash_button_label_;
+  Gtk::Button flash_button_;
+  Gtk::Button fade_button_;
+  IconButton icon_button_;
+  Gtk::EventBox event_box_;
+  Gtk::Label name_label_{"<..>"};
 
-  bool _holdUpdates;
+  bool hold_updates_ = false;
 
   sigc::connection update_display_settings_connection_;
   size_t counter_ = 0;
 
   virtual void OnAssigned(bool moveFader) override;
-  void onIconClicked();
-  bool onFlashButtonPressed(GdkEventButton *event);
-  bool onFlashButtonReleased(GdkEventButton *event);
+  void OnIconClicked();
+  bool OnFlashButtonPressed(GdkEventButton *event);
+  bool OnFlashButtonReleased(GdkEventButton *event);
+  void OnFade();
   bool HandleRightRelease(GdkEventButton *event);
   void UpdateDisplaySettings();
+  void UpdateActivated(const theatre::SingleSourceValue &value);
 };
 
 }  // namespace glight::gui

--- a/gui/windows/mainmenu.cpp
+++ b/gui/windows/mainmenu.cpp
@@ -4,26 +4,7 @@
 
 namespace glight::gui {
 
-MainMenu::MainMenu()
-    : _miFile("_File", true),
-      _miDesign("_Design", true),
-      _miWindow("_Window", true),
-      _miNew("New"),
-      _miOpen("_Open...", true),
-      _miSave("Save _as...", true),
-      _miImport("_Import fixtures...", true),
-      _miQuit("_Quit", true),
-      _miBlackOut("Black-out"),
-      _miLockLayout("Lock layout"),
-      _miProtectBlackout("Protect black-out"),
-      _miDesignWizard("Design wizard"),
-      _miSideBar("Side bar"),
-      _miFullScreen("Full screen"),
-      _miFixtureListWindow("Fixtures"),
-      _miFixtureTypesWindow("Fixture types"),
-      _miFaderWindowMenu("Fader windows"),
-      _miNewFaderWindow("New"),
-      _miSceneWindow("Scene") {
+MainMenu::MainMenu() {
   _miNew.signal_activate().connect(New);
   _menuFile.append(_miNew);
 

--- a/gui/windows/mainmenu.h
+++ b/gui/windows/mainmenu.h
@@ -64,22 +64,29 @@ class MainMenu : public Gtk::MenuBar {
  private:
   Gtk::Menu _menuFile, _menuDesign, _menuWindow, _menuFaderWindows;
 
-  Gtk::MenuItem _miFile, _miDesign, _miWindow;
-  Gtk::MenuItem _miNew, _miOpen, _miSave, _miImport, _miQuit;
-  Gtk::MenuItem _miBlackOut;
-  Gtk::CheckMenuItem _miLockLayout;
-  Gtk::CheckMenuItem _miProtectBlackout;
-  Gtk::SeparatorMenuItem _miDesignSep1, _miDesignSep2;
-  Gtk::MenuItem _miDesignWizard;
-  Gtk::CheckMenuItem _miSideBar;
-  Gtk::CheckMenuItem _miFullScreen;
-  Gtk::CheckMenuItem _miFixtureListWindow;
-  Gtk::CheckMenuItem _miFixtureTypesWindow;
-  Gtk::MenuItem _miFaderWindowMenu;
-  Gtk::MenuItem _miNewFaderWindow;
+  Gtk::MenuItem _miFile{"_File", true};
+  Gtk::MenuItem _miDesign{"_Design", true};
+  Gtk::MenuItem _miWindow{"_Window", true};
+  Gtk::MenuItem _miNew{"New"};
+  Gtk::MenuItem _miOpen{"_Open...", true};
+  Gtk::MenuItem _miSave{"Save _as...", true};
+  Gtk::MenuItem _miImport{"_Import fixtures...", true};
+  Gtk::MenuItem _miQuit{"_Quit", true};
+  Gtk::MenuItem _miBlackOut{"Black-out"};
+  Gtk::CheckMenuItem _miLockLayout{"Lock layout"};
+  Gtk::CheckMenuItem _miProtectBlackout{"Protect black-out"};
+  Gtk::SeparatorMenuItem _miDesignSep1;
+  Gtk::SeparatorMenuItem _miDesignSep2;
+  Gtk::MenuItem _miDesignWizard{"Design wizard"};
+  Gtk::CheckMenuItem _miSideBar{"Side bar"};
+  Gtk::CheckMenuItem _miFullScreen{"Full screen"};
+  Gtk::CheckMenuItem _miFixtureListWindow{"Fixtures"};
+  Gtk::CheckMenuItem _miFixtureTypesWindow{"Fixture types"};
+  Gtk::MenuItem _miFaderWindowMenu{"Fader windows"};
+  Gtk::MenuItem _miNewFaderWindow{"New"};
   Gtk::SeparatorMenuItem _miFaderWindowSeperator;
   std::vector<Gtk::CheckMenuItem> _miFaderWindows;
-  Gtk::CheckMenuItem _miSceneWindow;
+  Gtk::CheckMenuItem _miSceneWindow{"Scene"};
 };
 
 }  // namespace glight::gui


### PR DESCRIPTION
Fixes #421.

It also improves the layout of the toggle and fader controls a bit, by making the flash button smaller.