### PR TITLE
Make audio device configurable and use 'default' as default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,6 +75,7 @@ set(GUIFILES
   gui/application.cpp
   gui/components/nameframe.cpp
   gui/functions.cpp
+  gui/instance.cpp
   gui/renderengine.cpp
   gui/components/audiowidget.cpp
   gui/components/beatinput.cpp
@@ -130,6 +131,7 @@ set(SYSTEMFILES
   system/jsonwriter.cpp
   system/openfixturereader.cpp
   system/reader.cpp
+  system/settings.cpp
   system/writer.cpp
   system/midi/controller.cpp
   system/midi/manager.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -208,6 +208,7 @@ if(Boost_FOUND)
     tests/system/tjsonreader.cpp
     tests/system/tjsonwriter.cpp
     tests/system/tmath.cpp
+    tests/system/tsettings.cpp
     tests/system/ttrackableptr.cpp
     tests/system/topenfixturereader.cpp
     tests/system/toptionalnumber.cpp

--- a/gui/instance.cpp
+++ b/gui/instance.cpp
@@ -1,0 +1,11 @@
+#include "instance.h"
+
+#include "system/settings.h"
+
+namespace glight::gui {
+
+Instance::Instance() { settings_ = std::make_unique<system::Settings>(); }
+
+Instance::~Instance() = default;
+
+}  // namespace glight::gui

--- a/gui/instance.h
+++ b/gui/instance.h
@@ -1,9 +1,15 @@
 #ifndef GLIGHT_GUI_INSTANCE_H_
 #define GLIGHT_GUI_INSTANCE_H_
 
+#include <memory>
+
 namespace glight {
 namespace theatre {
 class Management;
+}
+
+namespace system {
+struct Settings;
 }
 
 namespace gui {
@@ -18,6 +24,12 @@ class GUIState;
  */
 class Instance {
  public:
+  Instance();
+  ~Instance();
+
+  Instance(const Instance&) = delete;
+  Instance& operator=(const Instance&) = delete;
+
   static Instance& Get() {
     static Instance instance;
     return instance;
@@ -37,11 +49,16 @@ class Instance {
   static GUIState& State() { return *Get().state_; }
   void SetState(GUIState& state) { state_ = &state; }
 
+  static system::Settings& Settings() { return *Get().settings_; }
+
  private:
+  // Because this class is used in many places, all members are pointers
+  // so that extra includes can be avoided.
   theatre::Management* management_;
   EventTransmitter* events_;
   FixtureSelection* selection_;
   GUIState* state_;
+  std::unique_ptr<system::Settings> settings_;
 };
 
 }  // namespace gui

--- a/gui/mainwindow/mainwindow.cpp
+++ b/gui/mainwindow/mainwindow.cpp
@@ -31,6 +31,7 @@
 
 #include "system/openfixturereader.h"
 #include "system/reader.h"
+#include "system/settings.h"
 #include "system/writer.h"
 
 #include "system/midi/manager.h"
@@ -50,7 +51,8 @@ MainWindow::MainWindow() {
   Instance::Get().SetState(_state);
   Instance::Get().SetSelection(_fixtureSelection);
   Instance::Get().SetEvents(*this);
-  _management = std::make_unique<theatre::Management>();
+  Instance::Settings() = system::LoadSettings();
+  _management = std::make_unique<theatre::Management>(Instance::Settings());
   Instance::Get().SetManagement(*_management);
   _management->StartBeatFinder();
   _management->GetUniverses().Open();
@@ -104,6 +106,8 @@ MainWindow::~MainWindow() {
   _faderWindows.clear();
 
   _management.reset();
+
+  system::Save(Instance::Settings());
 }
 
 void MainWindow::InitializeMenu() {

--- a/system/audioplayer.cpp
+++ b/system/audioplayer.cpp
@@ -12,20 +12,8 @@ void AudioPlayer::open() {
   snd_pcm_uframes_t buffer_size = _alsaBufferSize;
   snd_pcm_uframes_t period_size = _alsaPeriodSize;
 
-  /*void **hints = nullptr;
-  if (snd_device_name_hint(-1, "pcm", &hints) < 0)
-    throw AlsaError("snd_device_name_hint() returned error");
-  size_t hi = 0;
-  while (hints[hi] != nullptr) {
-    char *deviceName = snd_device_name_get_hint(hints[hi], "NAME");
-    std::cout << " - " << deviceName << '\n';
-    free(deviceName);
-    ++hi;
-  }
-  snd_device_name_free_hint(hints);*/
-
   // Open PCM device for playback.
-  int rc = snd_pcm_open(&_handle, "pulse", SND_PCM_STREAM_PLAYBACK, 0);
+  int rc = snd_pcm_open(&_handle, "default", SND_PCM_STREAM_PLAYBACK, 0);
   if (rc < 0)
     throw AlsaError(std::string("snd_pcm_open() returned: ") +
                     snd_strerror(rc));

--- a/system/audioplayer.cpp
+++ b/system/audioplayer.cpp
@@ -13,7 +13,8 @@ void AudioPlayer::open() {
   snd_pcm_uframes_t period_size = _alsaPeriodSize;
 
   // Open PCM device for playback.
-  int rc = snd_pcm_open(&_handle, "default", SND_PCM_STREAM_PLAYBACK, 0);
+  int rc =
+      snd_pcm_open(&_handle, device_name_.c_str(), SND_PCM_STREAM_PLAYBACK, 0);
   if (rc < 0)
     throw AlsaError(std::string("snd_pcm_open() returned: ") +
                     snd_strerror(rc));

--- a/system/audioplayer.h
+++ b/system/audioplayer.h
@@ -31,8 +31,9 @@ class AudioPlayer : private SyncListener {
         : runtime_error(std::string("Alsa error: ") + message) {}
   };
 
-  AudioPlayer(FlacDecoder &decoder)
-      : _alsaPeriodSize(256),
+  AudioPlayer(FlacDecoder &decoder, const std::string &device_name)
+      : device_name_(device_name),
+        _alsaPeriodSize(256),
         _alsaBufferSize(2048),
         _alsaThread(),
         _isStopping(false),
@@ -62,6 +63,7 @@ class AudioPlayer : private SyncListener {
   void SetSyncListener(SyncListener &listener) { _syncListener = &listener; }
 
  private:
+  std::string device_name_;
   unsigned char _alsaBuffer[1024 * 64 * 4];
   snd_pcm_t *_handle;
   unsigned _alsaPeriodSize;

--- a/system/jsonreader.h
+++ b/system/jsonreader.h
@@ -144,6 +144,12 @@ inline std::string OptionalString(const Object &parent, const char *name,
   return iter == parent.end() ? default_value : ToStr(*iter);
 }
 
+inline void AssignOptionalString(std::string &value, const Object &parent,
+                                 const char *name) {
+  const Object::const_iterator iter = parent.find(name);
+  if (iter != parent.end()) value = ToStr(*iter);
+}
+
 namespace details {
 bool ReadNumber(char first, std::istream &stream, std::string &data);
 bool ReadString(std::istream &stream, std::string &data);

--- a/system/jsonwriter.h
+++ b/system/jsonwriter.h
@@ -63,13 +63,13 @@ class JsonWriter {
   void Number(unsigned number) { IntegerNumber(number); }
   void Number(size_t number) { IntegerNumber(number); }
 
-  void String(const std::string& str) {
+  void String(std::string_view str) {
     Next();
-    Out() << Encode(std::string_view(str));
+    Out() << Encode(str);
     state_ = State::AfterItem;
   }
 
-  void String(const char* name, const std::string& str) {
+  void String(const char* name, std::string_view str) {
     Name(name);
     String(str);
   }

--- a/system/reader.cpp
+++ b/system/reader.cpp
@@ -632,7 +632,7 @@ void Read(const std::string &filename, Management &management,
 
 void ImportFixtureTypes(const std::string &filename,
                         theatre::Management &management) {
-  theatre::Management file_management;
+  theatre::Management file_management(management.Settings());
   system::Read(filename, file_management);
   const std::vector<TrackablePtr<theatre::FixtureType>> &new_types =
       file_management.GetTheatre().FixtureTypes();

--- a/system/settings.cpp
+++ b/system/settings.cpp
@@ -1,0 +1,101 @@
+#include "settings.h"
+
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+
+#include <glibmm/miscutils.h>
+
+#include "jsonreader.h"
+#include "jsonwriter.h"
+
+namespace glight::system {
+
+using json::AssignOptionalString;
+using json::Node;
+using json::Object;
+using json::ToObj;
+
+namespace {
+
+std::string GetConfigDir() {
+  return std::filesystem::path(Glib::get_user_config_dir()) / "glight";
+}
+
+std::string GetConfigFilename(std::string_view config_dir) {
+  return (std::filesystem::path(config_dir) / "config").string();
+}
+
+bool TryMakeDir(const std::filesystem::path path) {
+  if (!std::filesystem::is_directory(path)) {
+    // We don't want to crash if the dir can't be created; we will just report
+    // an error to the cmd line
+    try {
+      std::filesystem::create_directories(path);
+    } catch (std::exception& exception) {
+      return false;
+    }
+  }
+  return true;
+}
+
+}  // namespace
+
+void Save(const Settings& settings) {
+  const std::string config_dir = GetConfigDir();
+  if (!TryMakeDir(config_dir))
+    std::cerr << "Could not create directory for config file (" << config_dir
+              << ")\n";
+  const std::string config_filename = GetConfigFilename(config_dir);
+  std::ofstream file(config_filename);
+  if (!file)
+    std::cerr << "Error saving config file: " << config_filename << '\n';
+  json::JsonWriter writer(file);
+
+  writer.StartObject();
+  writer.StartObject("system");
+  writer.StartObject("audio");
+  writer.String("input", settings.audio_input);
+  writer.String("output", settings.audio_output);
+  writer.EndObject();  // audio
+  writer.EndObject();  // system
+  writer.EndObject();  // main
+}
+
+void ParseAudio(Settings& settings, const Object& audio) {
+  AssignOptionalString(settings.audio_input, audio, "input");
+  AssignOptionalString(settings.audio_output, audio, "output");
+}
+
+void ParseSystem(Settings& settings, const Object& system) {
+  if (system.contains("audio")) {
+    ParseAudio(settings, ToObj(system["audio"]));
+  }
+}
+
+Settings LoadSettings() {
+  Settings settings;
+  const std::string config_filename = GetConfigFilename(GetConfigDir());
+  // If there's no file yet, return default settings without a message
+  if (!std::filesystem::exists(config_filename)) return settings;
+  std::ifstream file(config_filename);
+  if (!file) {
+    std::cout << "Could not open configuration file: using default settings.\n";
+    return settings;
+  }
+
+  try {
+    std::unique_ptr<Node> json_node = json::Parse(file);
+    const Object& json_config = ToObj(*json_node);
+    if (json_config.contains("system")) {
+      ParseSystem(settings, ToObj(json_config["system"]));
+    }
+  } catch (std::exception& exception) {
+    std::cerr << "Failed to read configuration file with error '"
+              << exception.what() << "': using default settings.\n";
+    settings = Settings();
+  }
+  return settings;
+}
+
+}  // namespace glight::system

--- a/system/settings.h
+++ b/system/settings.h
@@ -1,0 +1,20 @@
+#ifndef GLIGHT_SYSTEM_SETTINGS_H_
+#define GLIGHT_SYSTEM_SETTINGS_H_
+
+#include <string>
+#include <vector>
+
+namespace glight::system {
+
+struct Settings {
+  std::string audio_input = "default";
+  std::string audio_output = "default";
+};
+
+Settings LoadSettings();
+
+void Save(const Settings& settings);
+
+}  // namespace glight::system
+
+#endif

--- a/tests/system/tfileformat.cpp
+++ b/tests/system/tfileformat.cpp
@@ -15,6 +15,8 @@
 #include "theatre/filters/automasterfilter.h"
 #include "theatre/filters/rgbfilter.h"
 
+#include "system/settings.h"
+
 #include "gui/state/guistate.h"
 
 #include "system/reader.h"
@@ -286,7 +288,8 @@ void CheckEqual(const Management &a, const Management &b) {
 BOOST_AUTO_TEST_SUITE(file_format)
 
 BOOST_AUTO_TEST_CASE(ReadAndWrite) {
-  Management write_management;
+  glight::system::Settings settings;
+  Management write_management(settings);
   FillManagement(write_management);
 
   glight::gui::GUIState guiState;
@@ -305,7 +308,7 @@ BOOST_AUTO_TEST_CASE(ReadAndWrite) {
   std::ostringstream stream;
   glight::system::Write(stream, write_management, &guiState);
 
-  Management read_management;
+  Management read_management(settings);
   //
   // Read and check if the result is correct
   //

--- a/tests/system/topenfixturereader.cpp
+++ b/tests/system/topenfixturereader.cpp
@@ -1,4 +1,5 @@
 #include "system/openfixturereader.h"
+#include "system/settings.h"
 
 #include "theatre/fixturetypefunction.h"
 #include "theatre/management.h"
@@ -660,7 +661,8 @@ const char* kFlatParQA12 = R"(
 BOOST_AUTO_TEST_SUITE(open_fixture_reader)
 
 BOOST_AUTO_TEST_CASE(read) {
-  Management management;
+  const glight::system::Settings settings;
+  Management management(settings);
   std::istringstream data_stream(kFlatParQA12);
   std::unique_ptr<json::Node> root = json::Parse(data_stream);
   theatre::Theatre& theatre = management.GetTheatre();

--- a/tests/system/tsettings.cpp
+++ b/tests/system/tsettings.cpp
@@ -1,0 +1,20 @@
+#include "system/settings.h"
+
+#include <boost/test/unit_test.hpp>
+
+namespace glight::system {
+
+BOOST_AUTO_TEST_SUITE(settings)
+
+BOOST_AUTO_TEST_CASE(load) {
+  const Settings settings = LoadSettings();
+  // Wherever this runs _may_ have a config file, so this test can only
+  // check if loading doesn't crash and settings that are excepted to be
+  // non-empty are in fact also non-empty.
+  BOOST_CHECK(!settings.audio_input.empty());
+  BOOST_CHECK(!settings.audio_output.empty());
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+}  // namespace glight::system

--- a/tests/theatre/tchase.cpp
+++ b/tests/theatre/tchase.cpp
@@ -7,6 +7,8 @@
 #include "theatre/sequence.h"
 #include "theatre/theatre.h"
 
+#include "system/settings.h"
+
 #include <boost/test/unit_test.hpp>
 
 #include <memory>
@@ -17,7 +19,8 @@ using glight::system::ObservingPtr;
 BOOST_AUTO_TEST_SUITE(chase)
 
 BOOST_AUTO_TEST_CASE(remove_indirect) {
-  Management management;
+  const glight::system::Settings settings;
+  Management management(settings);
   Folder &root = management.RootFolder();
   ObservingPtr<FixtureType> ft =
       management.GetTheatre().AddFixtureTypePtr(StockFixture::Light1Ch);

--- a/tests/theatre/tfixturecontrol.cpp
+++ b/tests/theatre/tfixturecontrol.cpp
@@ -1,3 +1,5 @@
+#include "system/settings.h"
+
 #include "theatre/fixturecontrol.h"
 #include "theatre/folder.h"
 #include "theatre/management.h"
@@ -18,7 +20,8 @@ using glight::system::ObservingPtr;
 BOOST_AUTO_TEST_SUITE(fixture_control)
 
 BOOST_AUTO_TEST_CASE(SetValue) {
-  Management management;
+  const glight::system::Settings settings;
+  Management management(settings);
   ObservingPtr<FixtureType> fixtureType =
       management.GetTheatre().AddFixtureTypePtr(StockFixture::Light1Ch);
   Fixture &fixture = *management.GetTheatre().AddFixture(*fixtureType);
@@ -44,7 +47,8 @@ BOOST_AUTO_TEST_CASE(SetValue) {
 }
 
 BOOST_AUTO_TEST_CASE(Filters) {
-  Management management;
+  const glight::system::Settings settings;
+  Management management(settings);
 
   {
     ObservingPtr<FixtureType> fixtureType =

--- a/tests/theatre/tfixturegroup.cpp
+++ b/tests/theatre/tfixturegroup.cpp
@@ -1,3 +1,5 @@
+#include "system/settings.h"
+
 #include "theatre/fixturegroup.h"
 #include "theatre/management.h"
 #include "theatre/theatre.h"
@@ -88,7 +90,8 @@ BOOST_AUTO_TEST_CASE(contains) {
 }
 
 BOOST_AUTO_TEST_CASE(add_to_management) {
-  Management management;
+  const glight::system::Settings settings;
+  Management management(settings);
   Theatre& theatre = management.GetTheatre();
   const theatre::FixtureType& type =
       *theatre.AddFixtureType(StockFixture::Rgb3Ch);

--- a/tests/theatre/tfixturetype.cpp
+++ b/tests/theatre/tfixturetype.cpp
@@ -1,3 +1,5 @@
+#include "system/settings.h"
+
 #include "theatre/fixture.h"
 #include "theatre/fixturetype.h"
 #include "theatre/management.h"
@@ -60,7 +62,8 @@ BOOST_AUTO_TEST_CASE(ShapeCount) {
 }
 
 Color testColor(StockFixture cl, const std::vector<unsigned char> &values) {
-  Management management;
+  const glight::system::Settings settings;
+  Management management(settings);
   const FixtureType &fixtureType = *management.GetTheatre().AddFixtureType(cl);
   Fixture &rgbFixture = *management.GetTheatre().AddFixture(fixtureType);
   ValueSnapshot snapShot(true, 1);
@@ -115,7 +118,8 @@ BOOST_AUTO_TEST_CASE(GetColor_RGBAWUV) {
 }
 
 BOOST_AUTO_TEST_CASE(GetRotation_AyraTDCSunrise) {
-  Management management;
+  const glight::system::Settings settings;
+  Management management(settings);
   const FixtureType &fixtureType =
       *management.GetTheatre().AddFixtureType(StockFixture::AyraTDCSunrise);
   Fixture &fixture = *management.GetTheatre().AddFixture(fixtureType);
@@ -129,7 +133,8 @@ BOOST_AUTO_TEST_CASE(GetRotation_AyraTDCSunrise) {
 }
 
 BOOST_AUTO_TEST_CASE(function_summary) {
-  Management management;
+  const glight::system::Settings settings;
+  Management management(settings);
 
   const FixtureType &rgb_type =
       *management.GetTheatre().AddFixtureType(StockFixture::Rgb3Ch);

--- a/tests/theatre/tfolder.cpp
+++ b/tests/theatre/tfolder.cpp
@@ -1,3 +1,5 @@
+#include "system/settings.h"
+
 #include "theatre/chase.h"
 #include "theatre/fixturecontrol.h"
 #include "theatre/folder.h"
@@ -123,7 +125,8 @@ BOOST_AUTO_TEST_CASE(GetAvailableName) {
 }
 
 BOOST_AUTO_TEST_CASE(FolderManagement) {
-  Management management;
+  const glight::system::Settings settings;
+  Management management(settings);
   Folder &root = management.RootFolder();
   BOOST_CHECK(root.Children().empty());
   root.SetName("a");
@@ -136,7 +139,8 @@ BOOST_AUTO_TEST_CASE(RemoveFolder) {
   // Test removal of a folder that contains dependencies to
   // other dependent items
 
-  Management management;
+  const glight::system::Settings settings;
+  Management management(settings);
   Folder &root = management.RootFolder();
   FixtureType &fixtureType =
       *management.GetTheatre().AddFixtureType(StockFixture::Light1Ch);

--- a/tests/theatre/tmanagement.cpp
+++ b/tests/theatre/tmanagement.cpp
@@ -9,6 +9,8 @@
 
 #include "theatre/effects/fadeeffect.h"
 
+#include "system/settings.h"
+
 #include <boost/test/unit_test.hpp>
 
 #include <memory>
@@ -19,14 +21,16 @@ using glight::system::ObservingPtr;
 BOOST_AUTO_TEST_SUITE(management)
 
 BOOST_AUTO_TEST_CASE(Destruct) {
-  Management management;
+  const glight::system::Settings settings;
+  Management management(settings);
   management.Run();
   BOOST_CHECK_THROW(management.Run(), std::exception);
   management.StartBeatFinder();
 }
 
 BOOST_AUTO_TEST_CASE(RemoveObject) {
-  Management management;
+  const glight::system::Settings settings;
+  Management management(settings);
   std::unique_ptr<FadeEffect> effectPtr(new FadeEffect());
   effectPtr->SetName("effect");
   BOOST_CHECK(management.RootFolder().Children().empty());
@@ -48,7 +52,8 @@ BOOST_AUTO_TEST_CASE(RemoveObject) {
 }
 
 BOOST_AUTO_TEST_CASE(GetSpecificControllables) {
-  Management management;
+  const glight::system::Settings settings;
+  Management management(settings);
   BOOST_CHECK_EQUAL(management.GetSpecificControllables<Controllable>().size(),
                     0);
   management.AddEffect(Effect::Make(EffectType::Fade));
@@ -68,7 +73,8 @@ BOOST_AUTO_TEST_CASE(GetSpecificControllables) {
 }
 
 BOOST_AUTO_TEST_CASE(RemoveUnusedFixtureType) {
-  Management management;
+  const glight::system::Settings settings;
+  Management management(settings);
 
   ObservingPtr<FixtureType> typeA =
       management.GetTheatre().AddFixtureTypePtr(StockFixture::Light1Ch);
@@ -93,7 +99,8 @@ BOOST_AUTO_TEST_CASE(RemoveUnusedFixtureType) {
 }
 
 BOOST_AUTO_TEST_CASE(RemoveUsedFixtureType) {
-  Management management;
+  const glight::system::Settings settings;
+  Management management(settings);
   ObservingPtr<FixtureType> fixtureType =
       management.GetTheatre().AddFixtureTypePtr(StockFixture::Light1Ch);
   management.RootFolder().Add(fixtureType);
@@ -110,7 +117,8 @@ BOOST_AUTO_TEST_CASE(RemoveUsedFixtureType) {
 }
 
 BOOST_AUTO_TEST_CASE(HasCycles) {
-  Management management;
+  const glight::system::Settings settings;
+  Management management(settings);
   BOOST_CHECK_EQUAL(management.HasCycle(), false);
 
   std::unique_ptr<FadeEffect> effectPtr(new FadeEffect());

--- a/tests/theatre/tpresetcollection.cpp
+++ b/tests/theatre/tpresetcollection.cpp
@@ -1,3 +1,5 @@
+#include "system/settings.h"
+
 #include "theatre/fixturecontrol.h"
 #include "theatre/management.h"
 #include "theatre/presetcollection.h"
@@ -14,7 +16,8 @@ using glight::system::TrackablePtr;
 BOOST_AUTO_TEST_SUITE(preset_collection)
 
 BOOST_AUTO_TEST_CASE(Add) {
-  Management management;
+  const glight::system::Settings settings;
+  Management management(settings);
   FixtureType &fixtureType =
       *management.GetTheatre().AddFixtureType(StockFixture::Light1Ch);
   Fixture &fixture = *management.GetTheatre().AddFixture(fixtureType);
@@ -32,7 +35,8 @@ BOOST_AUTO_TEST_CASE(Add) {
 }
 
 BOOST_AUTO_TEST_CASE(SetValue) {
-  Management management;
+  const glight::system::Settings settings;
+  Management management(settings);
   FixtureType &fixtureType =
       *management.GetTheatre().AddFixtureType(StockFixture::Light1Ch);
   Fixture &fixture = *management.GetTheatre().AddFixture(fixtureType);

--- a/tests/theatre/tscene.cpp
+++ b/tests/theatre/tscene.cpp
@@ -1,3 +1,5 @@
+#include "system/settings.h"
+
 #include "theatre/management.h"
 
 #include "theatre/scenes/scene.h"
@@ -12,7 +14,8 @@ using system::TrackablePtr;
 BOOST_AUTO_TEST_SUITE(scene)
 
 BOOST_AUTO_TEST_CASE(make) {
-  Management management;
+  const glight::system::Settings settings;
+  Management management(settings);
   const TrackablePtr<Controllable>& scene_ptr = management.AddScene(true);
   BOOST_CHECK(scene_ptr);
   Scene& scene = static_cast<Scene&>(*scene_ptr);

--- a/tests/theatre/ttheatre.cpp
+++ b/tests/theatre/ttheatre.cpp
@@ -1,3 +1,5 @@
+#include "system/settings.h"
+
 #include "theatre/fixturecontrol.h"
 #include "theatre/folder.h"
 #include "theatre/management.h"
@@ -13,7 +15,8 @@ using system::ObservingPtr;
 BOOST_AUTO_TEST_SUITE(theatre)
 
 BOOST_AUTO_TEST_CASE(add_fixture) {
-  Management management;
+  const glight::system::Settings settings;
+  Management management(settings);
   FixtureType &fixtureType =
       *management.GetTheatre().AddFixtureType(StockFixture::Rgb3Ch);
   Fixture &fixture = *management.GetTheatre().AddFixture(fixtureType);
@@ -31,7 +34,8 @@ BOOST_AUTO_TEST_CASE(add_fixture) {
 }
 
 BOOST_AUTO_TEST_CASE(AddMany) {
-  Management management;
+  const glight::system::Settings settings;
+  Management management(settings);
   FixtureType &fixtureType =
       *management.GetTheatre().AddFixtureType(StockFixture::Rgb3Ch);
   Fixture *fixture = management.GetTheatre().AddFixture(fixtureType).Get();
@@ -56,7 +60,8 @@ BOOST_AUTO_TEST_CASE(AddMany) {
 }
 
 BOOST_AUTO_TEST_CASE(remove_fixture) {
-  Management management;
+  const glight::system::Settings settings;
+  Management management(settings);
   ObservingPtr<FixtureType> fixtureType =
       management.GetTheatre().AddFixtureTypePtr(StockFixture::Rgb3Ch);
   management.RootFolder().Add(fixtureType);

--- a/theatre/devices/beatfinder.cpp
+++ b/theatre/devices/beatfinder.cpp
@@ -14,7 +14,8 @@ void BeatFinder::open() {
   if (_isOpen) throw AlsaError("Alsa was opened twice");
 
   // Open PCM device for capture.
-  int rc = snd_pcm_open(&_handle, "default", SND_PCM_STREAM_CAPTURE, 0);
+  int rc =
+      snd_pcm_open(&_handle, device_name_.c_str(), SND_PCM_STREAM_CAPTURE, 0);
   if (rc < 0) throw AlsaError(snd_strerror(rc));
   _isOpen = true;
 

--- a/theatre/devices/beatfinder.cpp
+++ b/theatre/devices/beatfinder.cpp
@@ -14,7 +14,7 @@ void BeatFinder::open() {
   if (_isOpen) throw AlsaError("Alsa was opened twice");
 
   // Open PCM device for capture.
-  int rc = snd_pcm_open(&_handle, "pulse", SND_PCM_STREAM_CAPTURE, 0);
+  int rc = snd_pcm_open(&_handle, "default", SND_PCM_STREAM_CAPTURE, 0);
   if (rc < 0) throw AlsaError(snd_strerror(rc));
   _isOpen = true;
 

--- a/theatre/devices/beatfinder.h
+++ b/theatre/devices/beatfinder.h
@@ -20,17 +20,9 @@ class BeatFinder {
         : runtime_error(std::string("Alsa error: ") + message) {}
   };
 
-  BeatFinder()
-      : _alsaPeriodSize(256),
-        _alsaBufferSize(2048),
-        _alsaThread(),
-        _isStopping(false),
-        _isOpen(false),
-        _beat(Beat()),
-        _audioLevel(0),
-        _minimumConfidence(0.05) {}
+  BeatFinder(const std::string &device_name) : device_name_(device_name) {}
 
-  virtual ~BeatFinder() { close(); }
+  ~BeatFinder() { close(); }
 
   void Start() {
     _alsaThread = std::make_unique<std::thread>([&]() { TryOpen(); });
@@ -54,10 +46,12 @@ class BeatFinder {
   }
 
   snd_pcm_t *_handle;
-  unsigned _alsaPeriodSize, _alsaBufferSize;
+  unsigned _alsaPeriodSize = 256;
+  unsigned _alsaBufferSize = 2048;
   std::unique_ptr<std::thread> _alsaThread;
-  std::atomic<bool> _isStopping;
-  bool _isOpen;
+  std::atomic<bool> _isStopping = false;
+  bool _isOpen = false;
+  std::string device_name_;
   std::mutex _mutex;
   struct Beat {
     Beat() = default;
@@ -65,9 +59,9 @@ class BeatFinder {
     float value = 0.0;
     float confidence = 0.0;
   };
-  std::atomic<Beat> _beat;
-  std::atomic<uint16_t> _audioLevel;
-  float _minimumConfidence;
+  std::atomic<Beat> _beat = Beat();
+  std::atomic<uint16_t> _audioLevel = 0;
+  float _minimumConfidence = 0.05;
 
   void open();
   void close();

--- a/theatre/management.cpp
+++ b/theatre/management.cpp
@@ -21,6 +21,8 @@
 
 #include "devices/beatfinder.h"
 
+#include "system/settings.h"
+
 #include "scenes/scene.h"
 
 namespace glight::theatre {
@@ -29,7 +31,8 @@ using system::MakeTrackable;
 using system::ObservingPtr;
 using system::TrackablePtr;
 
-Management::Management() : _theatre(std::make_unique<Theatre>()) {
+Management::Management(const system::Settings &settings)
+    : settings_(settings), _theatre(std::make_unique<Theatre>()) {
   _rootFolder = _folders.emplace_back(MakeTrackable<Folder>()).Get();
   _rootFolder->SetName("Root");
 }
@@ -44,7 +47,7 @@ Management::~Management() {
 }
 
 void Management::StartBeatFinder() {
-  _beatFinder = std::make_unique<BeatFinder>();
+  _beatFinder = std::make_unique<BeatFinder>(settings_.audio_input);
   _beatFinder->Start();
 }
 

--- a/theatre/management.h
+++ b/theatre/management.h
@@ -15,6 +15,10 @@
 
 #include "devices/universemap.h"
 
+namespace glight::system {
+struct Settings;
+}
+
 namespace glight::theatre {
 
 /**
@@ -22,7 +26,7 @@ namespace glight::theatre {
  */
 class Management {
  public:
-  Management();
+  Management(const system::Settings &settings);
   ~Management();
 
   void Clear();
@@ -150,6 +154,8 @@ class Management {
 
   std::mutex &Mutex() { return _mutex; }
 
+  const system::Settings &Settings() const { return settings_; }
+
   FolderObject &GetObjectFromPath(const std::string &path) const;
 
   FolderObject *GetObjectFromPathIfExists(const std::string &path) const;
@@ -238,6 +244,7 @@ class Management {
   std::unique_ptr<std::thread> _thread;
   std::atomic<bool> _isQuitting = false;
   mutable std::mutex _mutex;
+  const system::Settings &settings_;
   std::chrono::time_point<std::chrono::steady_clock> _createTime =
       std::chrono::steady_clock::now();
   std::mt19937 _randomGenerator;

--- a/theatre/scenes/scene.cpp
+++ b/theatre/scenes/scene.cpp
@@ -2,6 +2,8 @@
 
 #include "../management.h"
 
+#include "system/settings.h"
+
 #include <iostream>
 
 namespace glight::theatre {
@@ -37,7 +39,8 @@ void Scene::initPlayer() {
       _audioPlayer.reset();
       _decoder.reset();
       _decoder = std::make_unique<system::FlacDecoder>(_audioFilename);
-      _audioPlayer = std::make_unique<system::AudioPlayer>(*_decoder);
+      _audioPlayer = std::make_unique<system::AudioPlayer>(
+          *_decoder, _management.Settings().audio_output);
       _audioPlayer->SetSyncListener(*this);
       try {  // Don't report an error when seeking fails
         _audioPlayer->Seek(_startOffset);


### PR DESCRIPTION
This MR adds support for reading and writing a configuration file, which for now has two entries: the audio input and output device name.