### PR TITLE
Don't list libxml2 as dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ The source of Glight can be downloaded from Github, currently from https://githu
 - [Flac++](https://xiph.org/flac/). `libflac++-dev` on Debian and Ubuntu.
 - [Alsa library](https://www.alsa-project.org/). `libasound2-dev` on Debian and Ubuntu.
 - [libola](https://www.openlighting.org/ola/). `libola-dev` and `libprotobuf-dev` on Debian and Ubuntu.
-- [libxml2](http://xmlsoft.org/). `libxml2-dev` on Debian and Ubuntu.
 
 For compilation, gcc version 11 or newer (or a similar version of clang) is required. All requirements are available under Ubuntu 22. Once the prerequisited are installed, glight can be compiled by running the following from the source directory:
 

--- a/scripts/docker/Ubuntu22
+++ b/scripts/docker/Ubuntu22
@@ -10,8 +10,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && apt-get update && \
     libboost-test-dev \
     libflac++-dev \
     libgtkmm-3.0-dev \
-    libola-dev \
-    libxml2-dev
+    libola-dev
 
 ADD . /src
 WORKDIR /src

--- a/scripts/docker/Ubuntu22-build-package
+++ b/scripts/docker/Ubuntu22-build-package
@@ -12,7 +12,6 @@ RUN export DEBIAN_FRONTEND=noninteractive && apt-get update && \
     libflac++-dev \
     libgtkmm-3.0-dev \
     libola-dev \
-    libxml2-dev \
     lsb-release
 
 ADD . /src

--- a/scripts/docker/Ubuntu24-build-package
+++ b/scripts/docker/Ubuntu24-build-package
@@ -12,7 +12,6 @@ RUN export DEBIAN_FRONTEND=noninteractive && apt-get update && \
     libflac++-dev \
     libgtkmm-3.0-dev \
     libola-dev \
-    libxml2-dev \
     lsb-release
 
 ADD . /src


### PR DESCRIPTION
In 2022 the dependency on libxml2 was removed, but it was still listed in some documentation and docker files.