### PR TITLE
Fix object context menu and other small things

### DIFF
--- a/gui/components/objectlist.h
+++ b/gui/components/objectlist.h
@@ -9,6 +9,7 @@
 #include <gtkmm/iconpaintable.h>
 #include <gtkmm/image.h>
 #include <gtkmm/liststore.h>
+#include <gtkmm/messagedialog.h>
 #include <gtkmm/popovermenu.h>
 #include <gtkmm/scrolledwindow.h>
 #include <gtkmm/treeview.h>
@@ -114,8 +115,9 @@ class ObjectList : public Gtk::ScrolledWindow {
   bool selectObject(const theatre::FolderObject &object,
                     const Gtk::TreeModel::Children &children);
   void constructContextMenu();
-  void constructFolderMenu(Gio::Menu &menu, Gio::SimpleActionGroup &actions,
-                           theatre::Folder &folder, int &counter);
+  void constructFolderMenu(const std::shared_ptr<Gio::Menu> &menu,
+                           Gio::ActionMap &actions, theatre::Folder &folder,
+                           int &counter);
   void onMoveSelected(theatre::Folder *destination);
   void onMoveUpSelected();
   void onMoveDownSelected();
@@ -126,6 +128,7 @@ class ObjectList : public Gtk::ScrolledWindow {
 
   RecursionLock _avoidRecursion;
   Gtk::PopoverMenu _contextMenu;
+  std::unique_ptr<Gtk::MessageDialog> dialog_;
 };
 
 }  // namespace glight::gui

--- a/gui/instance.h
+++ b/gui/instance.h
@@ -3,6 +3,10 @@
 
 #include <memory>
 
+namespace Gtk {
+class ApplicationWindow;
+}
+
 namespace glight {
 namespace theatre {
 class Management;
@@ -51,6 +55,11 @@ class Instance {
 
   static system::Settings& Settings() { return *Get().settings_; }
 
+  static Gtk::ApplicationWindow& MainWindow() { return *Get().main_window_; }
+  void SetMainWindow(Gtk::ApplicationWindow& main_window) {
+    main_window_ = &main_window;
+  }
+
  private:
   // Because this class is used in many places, all members are pointers
   // so that extra includes can be avoided.
@@ -58,6 +67,7 @@ class Instance {
   EventTransmitter* events_;
   FixtureSelection* selection_;
   GUIState* state_;
+  Gtk::ApplicationWindow* main_window_;
   std::unique_ptr<system::Settings> settings_;
 };
 

--- a/gui/mainwindow/mainwindow.cpp
+++ b/gui/mainwindow/mainwindow.cpp
@@ -50,6 +50,7 @@ MainWindow::MainWindow() : main_menu_(*this) {
   Instance::Get().SetState(_state);
   Instance::Get().SetSelection(_fixtureSelection);
   Instance::Get().SetEvents(*this);
+  Instance::Get().SetMainWindow(*this);
   Instance::Settings() = system::LoadSettings();
   _management = std::make_unique<theatre::Management>(Instance::Settings());
   Instance::Get().SetManagement(*_management);

--- a/gui/menufunctions.h
+++ b/gui/menufunctions.h
@@ -8,7 +8,7 @@
 namespace glight::gui {
 
 inline std::shared_ptr<Gio::SimpleAction> AddMenuItem(
-    Gio::ActionMap& actions, std::shared_ptr<Gio::Menu>& menu,
+    Gio::ActionMap& actions, const std::shared_ptr<Gio::Menu>& menu,
     const Glib::ustring& label, const Glib::ustring& action_name,
     const sigc::slot<void()>& slot) {
   menu->append(label, "win." + action_name);
@@ -16,7 +16,7 @@ inline std::shared_ptr<Gio::SimpleAction> AddMenuItem(
 };
 
 inline std::shared_ptr<Gio::SimpleAction> AddToggleMenuItem(
-    Gio::ActionMap& actions, std::shared_ptr<Gio::Menu>& menu,
+    Gio::ActionMap& actions, const std::shared_ptr<Gio::Menu>& menu,
     const Glib::ustring& label, const Glib::ustring& action_name,
     bool initial_value, const sigc::slot<void(bool)>& slot) {
   auto action_toggle =

--- a/gui/windows/fixturetypeswindow.cpp
+++ b/gui/windows/fixturetypeswindow.cpp
@@ -40,6 +40,7 @@ FixtureTypesWindow::FixtureTypesWindow() : functions_frame_(*this) {
   tree_view_.append_column("Functions", list_columns_.functions_);
   tree_view_.get_selection()->signal_changed().connect(
       [&]() { onSelectionChanged(); });
+  tree_view_.set_expand(true);
   fillList();
   type_scrollbars_.set_child(tree_view_);
 
@@ -48,8 +49,7 @@ FixtureTypesWindow::FixtureTypesWindow() : functions_frame_(*this) {
   left_box_.append(type_scrollbars_);
 
   paned_.set_start_child(left_box_);
-  left_box_.set_hexpand(true);
-  left_box_.set_vexpand(true);
+  left_box_.set_expand(true);
 
   // Right part
   right_grid_.attach(name_label_, 0, 0);


### PR DESCRIPTION
- Fix object context menu after gtkmm 4 changes
- Fix crash when object is moved to folder where a same named object already exists
- Fix layout of fixture types window
- Make sure random selection doesn't select the same output twice
- Make sure timer effect doesn't initiate fade-out on first activation